### PR TITLE
Added sanitisation of url for cli commands that open new tabs

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -73,8 +73,8 @@ export function startCli() {
           demandOption: true,
         }),
       async ({ url }) => {
-        url = sanitiseUrl(url);
-        await makeNewTab(url)
+        const sanitisedUrl = sanitiseUrl(url);
+        await makeNewTab(sanitisedUrl)
       } 
     )
     .command(
@@ -114,8 +114,8 @@ export function startCli() {
           demandOption: true,
         }),
       async ({ url }) => {
-        url = sanitiseUrl(url);
-        await makeNewLittleArcWindow(url);
+        const sanitisedUrl = sanitiseUrl(url);
+        await makeNewLittleArcWindow(sanitisedUrl);
       } 
     );
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,16 +1,17 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import {
-  getVersion,
-  getSpaces,
-  selectSpace,
-  getTabs,
-  makeNewTab,
-  makeNewLittleArcWindow,
-  selectTab,
-  reloadTab,
   closeTab,
+  getSpaces,
+  getTabs,
+  getVersion,
+  makeNewLittleArcWindow,
+  makeNewTab,
+  reloadTab,
+  selectSpace,
+  selectTab,
 } from "./arc.js";
+import { sanitiseUrl } from "./utils/sanitise-url.js";
 
 export function startCli() {
   const cli = yargs(hideBin(process.argv))
@@ -71,7 +72,10 @@ export function startCli() {
           type: "string",
           demandOption: true,
         }),
-      async ({ url }) => await makeNewTab(url)
+      async ({ url }) => {
+        url = sanitiseUrl(url);
+        await makeNewTab(url)
+      } 
     )
     .command(
       ["select-tab <window-id> <tab-id>", "st <window-id> <tab-id>"],
@@ -109,7 +113,10 @@ export function startCli() {
           type: "string",
           demandOption: true,
         }),
-      async ({ url }) => await makeNewLittleArcWindow(url)
+      async ({ url }) => {
+        url = sanitiseUrl(url);
+        await makeNewLittleArcWindow(url);
+      } 
     );
 
   // If there are no args passed, show help screen

--- a/src/utils/sanitise-url.ts
+++ b/src/utils/sanitise-url.ts
@@ -1,7 +1,7 @@
 export function sanitiseUrl(url: string): string {
     // if url does not start with http or https, prepend https
   if (!url.startsWith("http://") && !url.startsWith("https://")) {
-    url = `https://${url}`;
+    return `https://${url}`;
   }
   return url;
 }

--- a/src/utils/sanitise-url.ts
+++ b/src/utils/sanitise-url.ts
@@ -1,0 +1,7 @@
+export function sanitiseUrl(url: string): string {
+    // if url does not start with http or https, prepend https
+  if (!url.startsWith("http://") && !url.startsWith("https://")) {
+    url = `https://${url}`;
+  }
+  return url;
+}


### PR DESCRIPTION
I encountered a problem with the new-tab command in that if my url didn't include "https://" then the tab would not open the page correctly.
If a use wants to open a tab with a url that they are not copy-pasting e.g "youtube.com", it can be a pain to have to type in the "https://".
I created a function called sanitiseUrl() that will parse the url and add the https at the start if it is missing, otherwise will leave it unaltered.
This is integrated into cli.ts, within the new-tab command, and the new-little-arc command.
Hopefully this helps improve the user experience :)